### PR TITLE
UI integration

### DIFF
--- a/.github/pr/ui_integration.md
+++ b/.github/pr/ui_integration.md
@@ -1,0 +1,62 @@
+UI integration
+
+Summary
+This PR adds a new WPF (.NET Framework 4.8) UI that embeds Discord via WebView2 and moves the bot automation directly into the UI (no Selenium/Chrome instance). It also replaces the root README with an English, UI‑focused guide and adds per‑file documentation for the UI and console components.
+
+Highlights
+- New WPF UI project EpicRPGBot.UI (WebView2-based)
+- In-app automation engine using WebView2 DevTools (Input.insertText + key events)
+- Reliable composer focus (avoids typing into the Discord header search)
+- Start Bot now:
+  - Immediately sends “rpg cd”
+  - Then continues with hunt/work/farm opening salvo based on Area
+  - Timers continue sending commands on cooldown
+- Left sidebar with two tabs:
+  - Stats: rolling last 5 messages (with timestamps)
+  - Console: structured logs (engine start/stop, commands sent)
+- Persistent WebView2 profile for Discord login
+- Clicks common interstitials automatically after navigation
+- README overhaul and English documentation for each code file
+
+What’s included
+- EpicRPGBot.UI/
+  - App.xaml, App.xaml.cs
+  - MainWindow.xaml, MainWindow.xaml.cs
+  - BotEngine.cs (WebView2 automation + timers + event hooks)
+  - Env.cs (simple .env loader)
+  - Services: InMemoryLog, LastMessagesBuffer, UiDispatcher
+  - README.md (UI usage, build and troubleshooting)
+  - docs/ (per-file docs)
+    - App.xaml.md
+    - EpicRPGBot.UI.csproj.md
+    - MainWindow.xaml.md
+    - MainWindow.xaml.cs.md
+    - BotEngine.cs.md
+    - InMemoryLog.cs.md
+    - LastMessagesBuffer.cs.md
+    - UiDispatcher.cs.md
+    - Env.cs.md
+- EpicRPGBotCSHARP/docs/Program.cs.md (console bot reference)
+- Root README.md replaced with English UI-focused README
+
+Behavioral notes
+- Composer focus: Engine picks the bottom-most visible role="textbox" (or data-slate-editor) element and focuses it before sending text via DevTools; falls back to execCommand if needed.
+- Start dedupe: Clicking Start while running is ignored (no duplicate ‘rpg cd’ and no double timers).
+- Message polling: The UI polls last message text and records into a rolling buffer for the Stats tab.
+
+How to run
+- Build: dotnet build EpicRPGBotCSharp.sln -c Debug
+- Run UI: dotnet run --project EpicRPGBot.UI -c Debug
+- Ensure WebView2 Runtime is installed (winget install Microsoft.EdgeWebView2Runtime)
+- Configure .env with DISCORD_CHANNEL_URL and cooldowns (see README)
+
+Screenshots
+- Not included yet; structure allows adding under EpicRPGBot.UI/docs/img and referencing them in README.
+
+Risks / follow-ups
+- Discord DOM can change; selectors are resilient but may require updates.
+- Future: expose engine events to the left panels directly (currently basic logging/polling is in place).
+- Optional: add more command customization and richer stats.
+
+License
+- MIT (project default).

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # VS/IDE cache
 .vs/
+.vscode/
 
 # User secrets / env
 .env

--- a/EpicRPGBot.UI/App.xaml
+++ b/EpicRPGBot.UI/App.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application x:Class="EpicRPGBot.UI.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/EpicRPGBot.UI/App.xaml.cs
+++ b/EpicRPGBot.UI/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace EpicRPGBot.UI
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/EpicRPGBot.UI/BotEngine.cs
+++ b/EpicRPGBot.UI/BotEngine.cs
@@ -1,0 +1,504 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace EpicRPGBot.UI
+{
+    public sealed class BotEngine
+    {
+        private readonly WebView2 _web;
+        private readonly DispatcherTimer _huntT;
+        private readonly DispatcherTimer _workT;
+        private readonly DispatcherTimer _farmT;
+        private readonly DispatcherTimer _checkMessageT;
+        private readonly Stopwatch _commandDelay = new Stopwatch();
+
+        private int _area;
+        private int _huntCooldown;
+        private int _workCooldown;
+        private int _farmCooldown;
+
+        private string _hunt = "rpg hunt h";
+        private string _work = "rpg chop";
+        private string _farm = "rpg farm";
+
+        private int _huntMarryTracker = 0;
+        private string _lastMessageId = string.Empty;
+
+        private bool _running;
+
+        // Expose running state for UI checks
+        public bool IsRunning => _running;
+
+        // Events for UI consumption
+        public event Action OnEngineStarted;
+        public event Action OnEngineStopped;
+        public event Action<string> OnCommandSent;
+        public event Action<string> OnMessageSeen;
+
+        // Tracks manual "rpg cd" to avoid duplicate opening cd when Start() runs
+        private DateTime _lastManualCdUtc = DateTime.MinValue;
+
+        public BotEngine(WebView2 web, int area, int huntCooldown, int workCooldown, int farmCooldown)
+        {
+            _web = web ?? throw new ArgumentNullException(nameof(web));
+
+            _area = area;
+            _huntCooldown = huntCooldown;
+            _workCooldown = workCooldown;
+            _farmCooldown = farmCooldown;
+
+            _huntT = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(_huntCooldown) };
+            _huntT.Tick += async (s, e) => await SendCommandAsync(_hunt);
+
+            _workT = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(_workCooldown) };
+            _workT.Tick += async (s, e) => await SendCommandAsync(_work);
+
+            _farmT = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(_farmCooldown) };
+            _farmT.Tick += async (s, e) => await SendCommandAsync(_farm);
+
+            _checkMessageT = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(2000) };
+            _checkMessageT.Tick += async (s, e) =>
+            {
+                try
+                {
+                    var msg = await CheckLastMessageAsync();
+                    if (!string.IsNullOrEmpty(msg))
+                    {
+                        EventCheck(msg);
+                    }
+                }
+                catch { }
+            };
+        }
+
+
+        public void Start()
+        {
+            if (_running) return;
+            _running = true;
+            OnEngineStarted?.Invoke();
+
+            // Choose work command based on area (mirrors Program.StartBot() switch)
+            if (_area == 3 || _area == 4 || _area == 5)
+                _work = "rpg axe";
+            else if (_area == 6 || _area == 7 || _area == 8)
+                _work = "rpg bowsaw";
+            else if (_area == 9 || _area == 10 || _area == 11 || _area == 12 || _area == 13)
+                _work = "rpg chainsaw";
+            else
+                _work = "rpg chop";
+
+            _commandDelay.Restart();
+
+            // Opening salvo (no immediate cd here; UI sends it before calling Start)
+            _ = Task.Run(async () =>
+            {
+                await SafeDelay(2001);
+                await SendMessageAsyncDevTools(_hunt);
+                OnCommandSent?.Invoke(_hunt);
+                await SafeDelay(2001);
+                await SendMessageAsyncDevTools(_work);
+                OnCommandSent?.Invoke(_work);
+                await SafeDelay(2001);
+                if (_area >= 4)
+                {
+                    await SendMessageAsyncDevTools(_farm);
+                    OnCommandSent?.Invoke(_farm);
+                }
+            });
+
+            StartTimers();
+        }
+
+        public void Stop()
+        {
+            if (!_running) return;
+            _running = false;
+            StopTimers();
+            OnEngineStopped?.Invoke();
+        }
+
+        private void StartTimers()
+        {
+            _huntT.Start();
+            _workT.Start();
+            if (_area >= 4) _farmT.Start();
+            _checkMessageT.Start();
+        }
+
+        private void StopTimers()
+        {
+            _huntT.Stop();
+            _workT.Stop();
+            _farmT.Stop();
+            _checkMessageT.Stop();
+        }
+
+        private async Task SendCommandAsync(string command)
+        {
+            if (!_running) return;
+            try
+            {
+                // Alternate marry tracker logic (same as Program.SendCommand)
+                if (command == "rpg hunt h" && _huntMarryTracker == 0)
+                {
+                    _huntMarryTracker = 1;
+                }
+                else if (command == "rpg hunt h" && _huntMarryTracker == 1)
+                {
+                    command = "rpg hunt h";
+                    _huntMarryTracker = 0;
+                }
+
+                if (_commandDelay.ElapsedMilliseconds > 2000)
+                {
+                    await SendMessageAsyncDevTools(command);
+                    OnCommandSent?.Invoke(command);
+                    _commandDelay.Restart();
+                    await SafeDelay(2001);
+                    var msg = await CheckLastMessageAsync();
+                    if (!string.IsNullOrEmpty(msg)) EventCheck(msg);
+                }
+                else
+                {
+                    await SafeDelay(2000);
+                    await SendMessageAsyncDevTools(command);
+                    OnCommandSent?.Invoke(command);
+                    _commandDelay.Restart();
+                    await SafeDelay(2001);
+                    var msg = await CheckLastMessageAsync();
+                    if (!string.IsNullOrEmpty(msg)) EventCheck(msg);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("SendCommand error: " + ex.Message);
+            }
+        }
+
+        // Focus the real message composer (bottom text editor), avoiding the header "Search" box.
+        private async Task<bool> FocusComposerAsync()
+        {
+            if (_web.CoreWebView2 == null) return false;
+
+            // Try for up to ~5 seconds
+            for (int i = 0; i < 10; i++)
+            {
+                var focused = await _web.CoreWebView2.ExecuteScriptAsync(@"
+(function(){
+  // Prefer Discord's Slate editor for message composing
+  let candidates = Array.from(document.querySelectorAll(
+    'div[role=""textbox""][data-slate-editor=""true""], ' +
+    'div[aria-label^=""Message""][role=""textbox""], ' +
+    'div[aria-label*=""Message""][role=""textbox""]'
+  ));
+  if (candidates.length === 0) {
+    // fallback to any role=textbox contenteditable true
+    candidates = Array.from(document.querySelectorAll('div[role=""textbox""], div[contenteditable=""true""]'));
+  }
+  // Filter visible
+  const vis = candidates.filter(el => {
+    const r = el.getBoundingClientRect();
+    const st = window.getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && st.visibility !== 'hidden' && st.display !== 'none';
+  });
+  const list = vis.length ? vis : candidates;
+  if (list.length === 0) return false;
+
+  // Pick bottom-most element (composer sits at the bottom of the chat)
+  list.sort((a,b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+  const editor = list[list.length - 1];
+
+  try { editor.scrollIntoView({block:'center'}); } catch(e) {}
+  try { editor.click(); } catch(e) {}
+  try { editor.focus(); } catch(e) {}
+
+  // Place caret at the end
+  try {
+    const r = document.createRange();
+    r.selectNodeContents(editor);
+    r.collapse(false);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(r);
+  } catch(e) {}
+
+  return document.activeElement === editor || true;
+})();");
+                if (string.Equals(focused?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                await Task.Delay(500);
+            }
+            return false;
+        }
+
+        // Primary send using DevTools Protocol (reliable on Discord)
+        private async Task<bool> SendMessageAsyncDevTools(string message)
+        {
+            if (_web.CoreWebView2 == null) return false;
+
+            if (!await FocusComposerAsync())
+                return false;
+
+            string text = (message ?? string.Empty)
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\r", "")
+                .Replace("\n", "\\n");
+
+            try
+            {
+                await _web.CoreWebView2.CallDevToolsProtocolMethodAsync(
+                    "Input.insertText",
+                    $"{{\"text\":\"{text}\"}}"
+                );
+
+                const string keyDown = "{\"type\":\"keyDown\",\"key\":\"Enter\",\"code\":\"Enter\",\"windowsVirtualKeyCode\":13,\"nativeVirtualKeyCode\":13}";
+                const string keyUp = "{\"type\":\"keyUp\",\"key\":\"Enter\",\"code\":\"Enter\",\"windowsVirtualKeyCode\":13,\"nativeVirtualKeyCode\":13}";
+
+                await _web.CoreWebView2.CallDevToolsProtocolMethodAsync("Input.dispatchKeyEvent", keyDown);
+                await _web.CoreWebView2.CallDevToolsProtocolMethodAsync("Input.dispatchKeyEvent", keyUp);
+
+                return true;
+            }
+            catch
+            {
+                // Fallback to execCommand if DevTools fails (rare)
+                try
+                {
+                    string escaped = text;
+                    string js = $@"
+(async () => {{
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  const editor = (function(){{
+    let c = Array.from(document.querySelectorAll('div[role=""textbox""][data-slate-editor=""true""], div[aria-label^=""Message""][role=""textbox""], div[aria-label*=""Message""][role=""textbox""]'));
+    if (c.length === 0) c = Array.from(document.querySelectorAll('div[role=""textbox""], div[contenteditable=""true""]'));
+    if (c.length === 0) return null;
+    c.sort((a,b)=>a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+    return c[c.length - 1];
+  }})();
+  if (!editor) return false;
+  editor.focus();
+  try {{
+    document.execCommand('insertText', false, ""{escaped}"");
+    await sleep(50);
+    const eDown = new KeyboardEvent('keydown', {{ key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true }});
+    const eUp = new KeyboardEvent('keyup', {{ key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true }});
+    editor.dispatchEvent(eDown);
+    editor.dispatchEvent(eUp);
+    return true;
+  }} catch (e) {{ return false; }}
+}})();
+";
+                    var r = (await _web.CoreWebView2.ExecuteScriptAsync(js))?.Trim();
+                    return string.Equals(r, "true", StringComparison.OrdinalIgnoreCase);
+                }
+                catch { return false; }
+            }
+        }
+
+        // Exposed helper to send immediately (used by Start button)
+        public async Task<bool> SendImmediateAsync(string text)
+        {
+            var ok = await SendMessageAsyncDevTools(text);
+            if (ok)
+            {
+                OnCommandSent?.Invoke(text);
+                if (string.Equals(text?.Trim(), "rpg cd", StringComparison.OrdinalIgnoreCase))
+                    _lastManualCdUtc = DateTime.UtcNow;
+            }
+            return ok;
+        }
+
+        private async Task<string> CheckLastMessageAsync()
+        {
+            if (_web.CoreWebView2 == null) return string.Empty;
+            string js = @"
+(() => {
+  const items = Array.from(document.querySelectorAll('li[id^=""chat-messages-""]'));
+  if (items.length === 0) return JSON.stringify({ id: '', text: '' });
+  const last = items[items.length - 1];
+  const obj = { id: (last.id || ''), text: (last.innerText || '') };
+  return JSON.stringify(obj);
+})();
+";
+            try
+            {
+                var json = await _web.CoreWebView2.ExecuteScriptAsync(js);
+                var s = UnquoteJson(json);
+                var id = ExtractField(s, "id");
+                var text = ExtractField(s, "text");
+
+                if (string.IsNullOrEmpty(id) || id == _lastMessageId) return string.Empty;
+                _lastMessageId = id;
+                OnMessageSeen?.Invoke(text);
+                return text ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string ExtractField(string json, string field)
+        {
+            if (string.IsNullOrEmpty(json)) return null;
+            var key = $"\"{field}\":";
+            int idx = json.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) return null;
+            idx += key.Length;
+            while (idx < json.Length && (json[idx] == ' ')) idx++;
+            bool quoted = idx < json.Length && json[idx] == '\"';
+            if (quoted) idx++;
+            int start = idx;
+            if (quoted)
+            {
+                while (idx < json.Length)
+                {
+                    if (json[idx] == '\\')
+                    {
+                        idx += 2;
+                        continue;
+                    }
+                    if (json[idx] == '\"') break;
+                    idx++;
+                }
+                var raw = json.Substring(start, Math.Max(0, idx - start));
+                return raw.Replace("\\n", "\n").Replace("\\r", "\r").Replace("\\t", "\t").Replace("\\\"", "\"").Replace("\\\\", "\\");
+            }
+            else
+            {
+                while (idx < json.Length && json[idx] != ',' && json[idx] != '}' && !char.IsWhiteSpace(json[idx])) idx++;
+                return json.Substring(start, Math.Max(0, idx - start)).Trim();
+            }
+        }
+
+        private static string UnquoteJson(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            s = s.Trim();
+            if (s.Length >= 2 && s[0] == '\"' && s[s.Length - 1] == '\"')
+            {
+                s = s.Substring(1, s.Length - 2);
+                s = s.Replace("\\n", "\n").Replace("\\r", "\r").Replace("\\t", "\t").Replace("\\\"", "\"").Replace("\\\\", "\\");
+            }
+            return s;
+        }
+
+        private void EventCheck(string message)
+        {
+            var msg = message ?? string.Empty;
+
+            if (msg.IndexOf("Select the item of the image above or respond with the item name", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                Debug.WriteLine("Guard seen");
+            }
+            else if (msg.IndexOf("TEST", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = SendMessageAsyncDevTools("I hear you: " + DateTime.Now);
+            }
+            else if (msg.IndexOf("BOT HELP", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = SendMessageAsyncDevTools("Change work - chop / axe / bowsaw / chainsaw ");
+                _ = SendMessageAsyncDevTools("Change farm - farm / potato / carrot / bread");
+                _ = SendMessageAsyncDevTools("bot farming - will start farming");
+            }
+            else if (msg.IndexOf("STOP", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                StopTimers();
+            }
+            else if (msg.IndexOf("START", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = Task.Run(async () =>
+                {
+                    await SendMessageAsyncDevTools("rpg cd");
+                    await SafeDelay(2001);
+                    await SendMessageAsyncDevTools(_hunt);
+                    await SafeDelay(2001);
+                    await SendMessageAsyncDevTools(_work);
+                    await SafeDelay(2001);
+                    if (_area >= 4)
+                        await SendMessageAsyncDevTools(_farm);
+                });
+                StartTimers();
+            }
+            else if (msg.IndexOf("wait at least", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                // cooldown info; ignore
+            }
+            else if (msg.IndexOf("CHANGE WORK", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                if (msg.IndexOf("CHOP", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _ = SendMessageAsyncDevTools("I am chopping treez");
+                    _work = "rpg chop";
+                }
+                else if (msg.IndexOf("AXE", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _ = SendMessageAsyncDevTools("I am using an axe");
+                    _work = "rpg axe";
+                }
+                else if (msg.IndexOf("BOWSAW", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _ = SendMessageAsyncDevTools("I am using a bowsaw");
+                    _work = "rpg bowsaw";
+                }
+                else if (msg.IndexOf("CHAINSAW", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _ = SendMessageAsyncDevTools("I am using a chainsaw");
+                    _work = "rpg chainsaw";
+                }
+            }
+            else if (msg.IndexOf("CHANGE FARM", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                if (msg.IndexOf("FARM FARM", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _farm = "rpg farm";
+                    _ = SendMessageAsyncDevTools("I am farming normally");
+                }
+                else if (msg.IndexOf("CARROT", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _farm = "rpg farm carrot";
+                    _ = SendMessageAsyncDevTools("I am farming carrots");
+                }
+                else if (msg.IndexOf("POTATO", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _farm = "rpg farm potato";
+                    _ = SendMessageAsyncDevTools("I am farming potatoes");
+                }
+                else if (msg.IndexOf("BREAD", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    _farm = "rpg farm bread";
+                    _ = SendMessageAsyncDevTools("I am farming bread");
+                }
+            }
+            else if (msg.IndexOf("BOT FARMING", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = SendMessageAsyncDevTools("I am farming");
+                if (!_farmT.IsEnabled)
+                {
+                    _farmT.Interval = TimeSpan.FromMilliseconds(_farmCooldown);
+                    _farmT.Start();
+                }
+            }
+            else if (msg.IndexOf("A LOOTBOX SUMMONING HAS", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = SendMessageAsyncDevTools("SUMMON");
+            }
+            else if (msg.IndexOf("A LEGENDARY BOSS JUST SPAWNED", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _ = SendMessageAsyncDevTools("TIME TO FIGHT");
+            }
+        }
+
+        private static Task SafeDelay(int ms)
+        {
+            return Task.Delay(ms);
+        }
+    }
+}

--- a/EpicRPGBot.UI/Env.cs
+++ b/EpicRPGBot.UI/Env.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+
+namespace EpicRPGBot.UI
+{
+    public static class Env
+    {
+        public static void Load()
+        {
+            try
+            {
+                var path = FindFileUpwards(".env");
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
+
+                foreach (var raw in File.ReadAllLines(path))
+                {
+                    var line = raw.Trim();
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#")) continue;
+
+                    int idx = line.IndexOf('=');
+                    if (idx <= 0) continue;
+
+                    string key = line.Substring(0, idx).Trim();
+                    string value = line.Substring(idx + 1).Trim();
+                    if ((value.StartsWith("\"") && value.EndsWith("\"")) || (value.StartsWith("'") && value.EndsWith("'")))
+                    {
+                        value = value.Substring(1, value.Length - 2);
+                    }
+                    Environment.SetEnvironmentVariable(key, value);
+                }
+            }
+            catch { }
+        }
+
+        public static string Get(string key, string fallback = null)
+        {
+            try
+            {
+                var v = Environment.GetEnvironmentVariable(key);
+                return string.IsNullOrWhiteSpace(v) ? fallback : v;
+            }
+            catch { return fallback; }
+        }
+
+        private static string FindFileUpwards(string fileName)
+        {
+            try
+            {
+                string current = AppDomain.CurrentDomain.BaseDirectory;
+                for (int i = 0; i < 8; i++)
+                {
+                    string candidate = Path.Combine(current, fileName);
+                    if (File.Exists(candidate)) return candidate;
+                    var parent = Directory.GetParent(current);
+                    if (parent == null) break;
+                    current = parent.FullName;
+                }
+            }
+            catch { }
+            return null;
+        }
+    }
+}

--- a/EpicRPGBot.UI/EpicRPGBot.UI.csproj
+++ b/EpicRPGBot.UI/EpicRPGBot.UI.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>EpicRPGBot.UI</RootNamespace>
+    <AssemblyName>EpicRPGBot.UI</AssemblyName>
+    <LangVersion>latest</LangVersion>
+    <PlatformTarget>x64</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/EpicRPGBot.UI/MainWindow.xaml
+++ b/EpicRPGBot.UI/MainWindow.xaml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window x:Class="EpicRPGBot.UI.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        mc:Ignorable="d"
+        Title="EpicRPG Bot UI" Height="800" Width="1300" WindowStartupLocation="CenterScreen">
+    <Grid Background="#1e1f22">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="260"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="300"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Left: Stats / Console -->
+        <Border Grid.Column="0" Background="#242529" BorderBrush="#2f3136" BorderThickness="0,0,1,0">
+            <DockPanel Margin="12">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,12">
+                    <Button Name="StatsTabBtn" Content="Stats" Margin="0,0,8,0" Padding="8,4" Click="StatsTabBtn_Click"/>
+                    <Button Name="ConsoleTabBtn" Content="Console" Padding="8,4" Click="ConsoleTabBtn_Click"/>
+                </StackPanel>
+
+                <Grid>
+                    <!-- Stats view: last 5 messages -->
+                    <Grid Name="StatsPanel" Visibility="Visible">
+                        <ListBox Name="StatsList"
+                                 Background="#1e1f22"
+                                 Foreground="#ddd"
+                                 BorderBrush="#3a3c42"
+                                 HorizontalContentAlignment="Stretch">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path=., Mode=OneWay}"
+                                               TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+
+                    <!-- Console view: log lines -->
+                    <Grid Name="ConsolePanel" Visibility="Collapsed">
+                        <ListBox Name="ConsoleList"
+                                 Background="#1e1f22"
+                                 Foreground="#ddd"
+                                 BorderBrush="#3a3c42"
+                                 HorizontalContentAlignment="Stretch">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path=., Mode=OneWay}"
+                                               TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Grid>
+            </DockPanel>
+        </Border>
+
+        <!-- Center: Discord Chat via WebView2 -->
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <DockPanel Grid.Row="0" Background="#2b2d31" LastChildFill="False">
+                <TextBlock Text="Discord" VerticalAlignment="Center" Margin="12,0,0,0" Foreground="#ddd" FontWeight="SemiBold"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,8,0">
+                    <Button Name="ReloadBtn" Content="Reload" Margin="8,6" Padding="12,4" Click="ReloadBtn_Click"/>
+                    <Button Name="GoChannelBtn" Content="Go To Channel" Margin="8,6" Padding="12,4" Click="GoChannelBtn_Click"/>
+                </StackPanel>
+            </DockPanel>
+
+            <Grid Grid.Row="1" Background="#1e1f22">
+                <wv2:WebView2 Name="Web" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+                <TextBlock Name="InitHint" Text="Loading WebView2..." Foreground="#bbb" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+            </Grid>
+        </Grid>
+
+        <!-- Right: Settings -->
+        <Border Grid.Column="2" Background="#242529" BorderBrush="#2f3136" BorderThickness="1,0,0,0">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="12">
+                    <TextBlock Text="Settings" Foreground="#ddd" FontSize="18" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                    <StackPanel Orientation="Vertical" Margin="0,4,0,0">
+                        <TextBlock Text="Discord Channel URL (.env DISCORD_CHANNEL_URL)" Foreground="#aaa"/>
+                        <TextBox Name="ChannelUrlBox" Margin="0,4,0,8" Background="#1e1f22" Foreground="#ddd" BorderBrush="#3a3c42"/>
+                        <CheckBox Name="UseAtMeFallback" Content="Fallback to @me if empty" Foreground="#ddd" IsChecked="True" Margin="0,0,0,12"/>
+                    </StackPanel>
+
+                    <Separator Background="#2f3136" Margin="0,8,0,12"/>
+
+                    <TextBlock Text="Bot Parameters" Foreground="#ddd" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <UniformGrid Columns="2" Rows="2" Margin="0,0,0,8">
+                        <StackPanel Margin="0,0,8,0">
+                            <TextBlock Text="Area" Foreground="#aaa"/>
+                            <TextBox Name="AreaBox" Text="10" Background="#1e1f22" Foreground="#ddd" BorderBrush="#3a3c42" Margin="0,4,0,0"/>
+                        </StackPanel>
+                        <StackPanel>
+                            <TextBlock Text="Hunt cooldown (ms)" Foreground="#aaa"/>
+                            <TextBox Name="HuntCdBox" Text="21000" Background="#1e1f22" Foreground="#ddd" BorderBrush="#3a3c42" Margin="0,4,0,0"/>
+                        </StackPanel>
+                        <StackPanel Margin="0,8,8,0">
+                            <TextBlock Text="Work cooldown (ms)" Foreground="#aaa"/>
+                            <TextBox Name="WorkCdBox" Text="99000" Background="#1e1f22" Foreground="#ddd" BorderBrush="#3a3c42" Margin="0,4,0,0"/>
+                        </StackPanel>
+                        <StackPanel Margin="0,8,0,0">
+                            <TextBlock Text="Farm cooldown (ms)" Foreground="#aaa"/>
+                            <TextBox Name="FarmCdBox" Text="196000" Background="#1e1f22" Foreground="#ddd" BorderBrush="#3a3c42" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </UniformGrid>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                        <Button Name="StartBtn" Content="Start Bot" Margin="0,0,8,0" Padding="12,4" Click="StartBtn_Click"/>
+                        <Button Name="StopBtn" Content="Stop Bot" Padding="12,4" Click="StopBtn_Click"/>
+                    </StackPanel>
+
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</Window>

--- a/EpicRPGBot.UI/MainWindow.xaml.cs
+++ b/EpicRPGBot.UI/MainWindow.xaml.cs
@@ -1,0 +1,281 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+using EpicRPGBot.UI.Services;
+using EpicRPGBot.UI.Models;
+
+namespace EpicRPGBot.UI
+{
+    public partial class MainWindow : Window
+    {
+        private DispatcherTimer _pollTimer;
+        private BotEngine _engine;
+
+        // UI data
+        private readonly InMemoryLog _log = new InMemoryLog();
+        private readonly LastMessagesBuffer _last = new LastMessagesBuffer(5);
+        private string _prevPolled = string.Empty;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            Loaded += MainWindow_Loaded;
+        }
+
+        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Load .env and seed UI
+            Env.Load();
+            ChannelUrlBox.Text = Env.Get("DISCORD_CHANNEL_URL", "https://discord.com/channels/@me");
+            AreaBox.Text = Env.Get("AREA", AreaBox.Text);
+            HuntCdBox.Text = Env.Get("HUNT_COOLDOWN", "21000");
+            WorkCdBox.Text = Env.Get("WORK_COOLDOWN", "99000");
+            FarmCdBox.Text = Env.Get("FARM_COOLDOWN", "196000");
+
+            // Bind left panels
+            StatsList.ItemsSource = _last.Items;
+            ConsoleList.ItemsSource = _log.Items;
+            _log.Engine("UI loaded");
+
+            await InitializeWebViewAsync();
+            await NavigateToChannelAsync(GetChannelUrl());
+            StartPollingLastMessage();
+        }
+
+        private string GetChannelUrl()
+        {
+            var url = ChannelUrlBox.Text?.Trim();
+            if (string.IsNullOrEmpty(url) && UseAtMeFallback.IsChecked == true)
+                return "https://discord.com/channels/@me";
+            return string.IsNullOrEmpty(url) ? "https://discord.com/channels/@me" : url;
+        }
+
+        private async Task InitializeWebViewAsync()
+        {
+            try
+            {
+                InitHint.Visibility = Visibility.Visible;
+                InitHint.Text = "Initializing WebView2...";
+
+                var dataDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "EpicRPGBot.UI", "WebView2");
+                Directory.CreateDirectory(dataDir);
+
+                var env = await CoreWebView2Environment.CreateAsync(null, dataDir);
+                await Web.EnsureCoreWebView2Async(env);
+
+                Web.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
+                Web.CoreWebView2.Settings.AreDevToolsEnabled = true;
+                Web.CoreWebView2.Settings.IsZoomControlEnabled = true;
+
+                Web.NavigationCompleted += async (s, e) =>
+                {
+                    try { await ClickInterstitialsAsync(); } catch { }
+                };
+
+                InitHint.Visibility = Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                InitHint.Visibility = Visibility.Visible;
+                InitHint.Text = "WebView2 init failed: " + ex.Message;
+            }
+        }
+
+        private async Task NavigateToChannelAsync(string url)
+        {
+            try
+            {
+                if (Web.CoreWebView2 != null)
+                {
+                    Web.CoreWebView2.Navigate(url);
+                }
+                else
+                {
+                    Web.Source = new Uri(url);
+                }
+            }
+            catch (Exception ex)
+            {
+                InitHint.Visibility = Visibility.Visible;
+                InitHint.Text = "Navigate failed: " + ex.Message;
+            }
+        }
+
+        private async Task ClickInterstitialsAsync()
+        {
+            if (Web.CoreWebView2 == null) return;
+
+            string script = @"
+(() => {
+  const byText = (txt) => {
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, null);
+    let clicked = false;
+    while (walker.nextNode()) {
+      const el = walker.currentNode;
+      if (!(el instanceof HTMLElement)) continue;
+      const t = (el.innerText || '').trim();
+      if (!t) continue;
+      if (t.includes(txt)) {
+        try { el.click(); clicked = true; } catch {}
+      }
+    }
+    return clicked;
+  };
+  let any = false;
+  any = byText('Open Discord in your browser') || any;
+  any = byText('Continue to Discord') || any;
+  any = byText('Continue in browser') || any;
+  return any;
+})();
+";
+            try { await Web.CoreWebView2.ExecuteScriptAsync(script); } catch { }
+        }
+
+        private void StartPollingLastMessage()
+        {
+            _pollTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+            _pollTimer.Tick += async (s, e) =>
+            {
+                try
+                {
+                    var msg = await GetLastMessageTextAsync();
+                    if (!string.IsNullOrWhiteSpace(msg) && !string.Equals(msg, _prevPolled, StringComparison.Ordinal))
+                    {
+                        _prevPolled = msg;
+                        UiDispatcher.OnUI(_last.Add, msg);
+                    }
+                }
+                catch { }
+            };
+            _pollTimer.Start();
+        }
+
+        private static string UnquoteJson(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            s = s.Trim();
+            if (s.Length >= 2 && s[0] == '\"' && s[s.Length - 1] == '\"')
+            {
+                s = s.Substring(1, s.Length - 2);
+                s = s.Replace("\\n", "\n").Replace("\\r", "\r").Replace("\\t", "\t").Replace("\\\"", "\"").Replace("\\\\", "\\");
+            }
+            return s;
+        }
+
+        private async Task<string> GetLastMessageTextAsync()
+        {
+            if (Web.CoreWebView2 == null) return null;
+            string js = @"
+(() => {
+  const items = Array.from(document.querySelectorAll(""li[id^='chat-messages-']""));
+  if (items.length === 0) return '';
+  const last = items[items.length - 1];
+  return last.innerText || '';
+})()
+";
+            var result = await Web.CoreWebView2.ExecuteScriptAsync(js);
+            return UnquoteJson(result);
+        }
+
+        private async Task<bool> SendMessageAsync(string message)
+        {
+            if (Web.CoreWebView2 == null) return false;
+            string escaped = (message ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n");
+            string js = $@"
+(async () => {{
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  const editor = document.querySelector(""div[role='textbox']"") || document.querySelector(""[contenteditable='true']"");
+  if (!editor) return false;
+  editor.focus();
+  try {{
+    document.execCommand('insertText', false, ""{escaped}"");
+    await sleep(50);
+    const eDown = new KeyboardEvent('keydown', {{ key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true }});
+    const eUp = new KeyboardEvent('keyup', {{ key:'Enter', code:'Enter', keyCode:13, which:13, bubbles:true, cancelable:true }});
+    editor.dispatchEvent(eDown);
+    editor.dispatchEvent(eUp);
+    return true;
+  }} catch (e) {{ return false; }}
+}})();
+";
+            try
+            {
+                var r = (await Web.CoreWebView2.ExecuteScriptAsync(js))?.Trim();
+                return string.Equals(r, "true", StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
+        private void ReloadBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (Web.CoreWebView2 != null) Web.CoreWebView2.Reload();
+                else Web.Reload();
+            }
+            catch { }
+        }
+
+        private async void GoChannelBtn_Click(object sender, RoutedEventArgs e)
+        {
+            await NavigateToChannelAsync(GetChannelUrl());
+        }
+
+        private async void StartBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _log.Info("Start button clicked");
+
+            // If engine already running, ignore per user instruction
+            if (_engine != null && (_engine.IsRunning))
+            {
+                _log.Info("Engine already running, Start ignored.");
+                return;
+            }
+
+            int area = SafeInt(AreaBox.Text, 10);
+            int hunt = SafeInt(HuntCdBox.Text, 21000);
+            int work = SafeInt(WorkCdBox.Text, 99000);
+            int farm = SafeInt(FarmCdBox.Text, 196000);
+
+            _engine = new BotEngine(Web, area, hunt, work, farm);
+
+            // Immediately send "rpg cd" before starting timers
+            var sent = await _engine.SendImmediateAsync("rpg cd");
+            _log.Info(sent ? "Sent 'rpg cd' immediately." : "Failed to send 'rpg cd'.");
+
+            // Then start engine timers and opening sequence (hunt/work[/farm])
+            _engine.Start();
+            _log.Engine("Engine started (timers running; hunt/work[/farm] scheduled)");
+        }
+
+        private void StopBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _engine?.Stop();
+            _log.Engine("Engine stopped");
+        }
+
+        private int SafeInt(string s, int def)
+        {
+            return int.TryParse(s, out var v) ? v : def;
+        }
+
+        // Left header buttons
+        private void StatsTabBtn_Click(object sender, RoutedEventArgs e)
+        {
+            StatsPanel.Visibility = Visibility.Visible;
+            ConsolePanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void ConsoleTabBtn_Click(object sender, RoutedEventArgs e)
+        {
+            StatsPanel.Visibility = Visibility.Collapsed;
+            ConsolePanel.Visibility = Visibility.Visible;
+        }
+    }
+}

--- a/EpicRPGBot.UI/Models/LogEntry.cs
+++ b/EpicRPGBot.UI/Models/LogEntry.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace EpicRPGBot.UI.Models
+{
+    public enum LogKind
+    {
+        Info,
+        Command,
+        Warning,
+        Error,
+        Engine
+    }
+
+    public sealed class LogEntry
+    {
+        public DateTime At { get; }
+        public LogKind Kind { get; }
+        public string Message { get; }
+
+        public LogEntry(LogKind kind, string message)
+        {
+            At = DateTime.Now;
+            Kind = kind;
+            Message = message ?? string.Empty;
+        }
+
+        public override string ToString() => $"[{At:HH:mm:ss}] {Kind}: {Message}";
+    }
+}

--- a/EpicRPGBot.UI/Models/MessageItem.cs
+++ b/EpicRPGBot.UI/Models/MessageItem.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace EpicRPGBot.UI.Models
+{
+    public sealed class MessageItem
+    {
+        public DateTime At { get; }
+        public string Text { get; }
+
+        public MessageItem(string text)
+        {
+            At = DateTime.Now;
+            Text = text ?? string.Empty;
+        }
+
+        public override string ToString() => $"[{At:HH:mm:ss}] {Text}";
+    }
+}

--- a/EpicRPGBot.UI/README.md
+++ b/EpicRPGBot.UI/README.md
@@ -12,22 +12,22 @@ Key behavior
 - The last 5 messages detected are shown in the Stats tab; all actions are logged in the Console tab.
 
 Project structure (UI-layer)
-- EpicRPGBot.UI/EpicRPGBot.UI.csproj
-- EpicRPGBot.UI/App.xaml
-- EpicRPGBot.UI/App.xaml.cs
-- EpicRPGBot.UI/MainWindow.xaml
-- EpicRPGBot.UI/MainWindow.xaml.cs
+- [EpicRPGBot.UI.csproj](EpicRPGBot.UI/EpicRPGBot.UI.csproj)
+- [App.xaml](EpicRPGBot.UI/App.xaml)
+- [App.xaml.cs](EpicRPGBot.UI/App.xaml.cs)
+- [MainWindow.xaml](EpicRPGBot.UI/MainWindow.xaml)
+- [MainWindow.xaml.cs](EpicRPGBot.UI/MainWindow.xaml.cs)
 - Engine:
-  - EpicRPGBot.UI/BotEngine.cs
+  - [BotEngine.cs](EpicRPGBot.UI/BotEngine.cs)
 - Models:
-  - EpicRPGBot.UI/Models/MessageItem.cs
-  - EpicRPGBot.UI/Models/LogEntry.cs
+  - [Models/MessageItem.cs](EpicRPGBot.UI/Models/MessageItem.cs)
+  - [Models/LogEntry.cs](EpicRPGBot.UI/Models/LogEntry.cs)
 - Services:
-  - EpicRPGBot.UI/Services/InMemoryLog.cs
-  - EpicRPGBot.UI/Services/LastMessagesBuffer.cs
-  - EpicRPGBot.UI/Services/UiDispatcher.cs
+  - [Services/InMemoryLog.cs](EpicRPGBot.UI/Services/InMemoryLog.cs)
+  - [Services/LastMessagesBuffer.cs](EpicRPGBot.UI/Services/LastMessagesBuffer.cs)
+  - [Services/UiDispatcher.cs](EpicRPGBot.UI/Services/UiDispatcher.cs)
 - Env loader (shared with original console app style):
-  - EpicRPGBot.UI/Env.cs
+  - [Env.cs](EpicRPGBot.UI/Env.cs)
 
 Requirements
 - .NET Framework 4.8 Developer Pack
@@ -72,14 +72,14 @@ Notes on behavior
 - Event scanning: The engine polls the DOM to capture the last chat message and triggers bot reactions for certain keywords.
 
 Files of interest
-- UI layout: EpicRPGBot.UI/MainWindow.xaml
-- UI logic / event wiring: EpicRPGBot.UI/MainWindow.xaml.cs
-- Bot automation: EpicRPGBot.UI/BotEngine.cs
+- UI layout: [MainWindow.xaml](EpicRPGBot.UI/MainWindow.xaml)
+- UI logic / event wiring: [MainWindow.xaml.cs](EpicRPGBot.UI/MainWindow.xaml.cs)
+- Bot automation: [BotEngine.cs](EpicRPGBot.UI/BotEngine.cs)
 - Logging and buffers:
-  - EpicRPGBot.UI/Services/InMemoryLog.cs
-  - EpicRPGBot.UI/Services/LastMessagesBuffer.cs
-  - EpicRPGBot.UI/Models/LogEntry.cs
-  - EpicRPGBot.UI/Models/MessageItem.cs
+  - [Services/InMemoryLog.cs](EpicRPGBot.UI/Services/InMemoryLog.cs)
+  - [Services/LastMessagesBuffer.cs](EpicRPGBot.UI/Services/LastMessagesBuffer.cs)
+  - [Models/LogEntry.cs](EpicRPGBot.UI/Models/LogEntry.cs)
+  - [Models/MessageItem.cs](EpicRPGBot.UI/Models/MessageItem.cs)
 
 Troubleshooting
 - WebView2 init failed:

--- a/EpicRPGBot.UI/Services/InMemoryLog.cs
+++ b/EpicRPGBot.UI/Services/InMemoryLog.cs
@@ -1,0 +1,28 @@
+using System.Collections.ObjectModel;
+using EpicRPGBot.UI.Models;
+
+namespace EpicRPGBot.UI.Services
+{
+    public sealed class InMemoryLog
+    {
+        public ObservableCollection<LogEntry> Items { get; } = new ObservableCollection<LogEntry>();
+
+        public void Info(string message) => Append(new LogEntry(LogKind.Info, message));
+        public void Command(string message) => Append(new LogEntry(LogKind.Command, message));
+        public void Warning(string message) => Append(new LogEntry(LogKind.Warning, message));
+        public void Error(string message) => Append(new LogEntry(LogKind.Error, message));
+        public void Engine(string message) => Append(new LogEntry(LogKind.Engine, message));
+
+        public void Append(LogEntry entry)
+        {
+            Items.Add(entry);
+            // Optionally trim if needed
+            if (Items.Count > 500)
+            {
+                // Keep last 500 lines
+                while (Items.Count > 500)
+                    Items.RemoveAt(0);
+            }
+        }
+    }
+}

--- a/EpicRPGBot.UI/Services/LastMessagesBuffer.cs
+++ b/EpicRPGBot.UI/Services/LastMessagesBuffer.cs
@@ -1,0 +1,29 @@
+using System.Collections.ObjectModel;
+using EpicRPGBot.UI.Models;
+
+namespace EpicRPGBot.UI.Services
+{
+    public sealed class LastMessagesBuffer
+    {
+        public int Capacity { get; }
+        public ObservableCollection<MessageItem> Items { get; } = new ObservableCollection<MessageItem>();
+
+        public LastMessagesBuffer(int capacity = 5)
+        {
+            Capacity = capacity <= 0 ? 5 : capacity;
+        }
+
+        public void Add(string text)
+        {
+            // newest first
+            Items.Insert(0, new MessageItem(text));
+            // trim to capacity
+            while (Items.Count > Capacity)
+            {
+                Items.RemoveAt(Items.Count - 1);
+            }
+        }
+
+        public void Clear() => Items.Clear();
+    }
+}

--- a/EpicRPGBot.UI/Services/UiDispatcher.cs
+++ b/EpicRPGBot.UI/Services/UiDispatcher.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace EpicRPGBot.UI.Services
+{
+    public static class UiDispatcher
+    {
+        public static Dispatcher Dispatcher => Application.Current?.Dispatcher;
+
+        public static void OnUI(Action action)
+        {
+            if (Dispatcher == null)
+            {
+                action?.Invoke();
+                return;
+            }
+
+            if (Dispatcher.CheckAccess())
+                action?.Invoke();
+            else
+                Dispatcher.BeginInvoke(action);
+        }
+
+        public static void OnUI<T>(Action<T> action, T arg)
+        {
+            if (Dispatcher == null)
+            {
+                action?.Invoke(arg);
+                return;
+            }
+
+            if (Dispatcher.CheckAccess())
+                action?.Invoke(arg);
+            else
+                Dispatcher.BeginInvoke(action, arg);
+        }
+    }
+}

--- a/EpicRPGBot.UI/docs/App.xaml.md
+++ b/EpicRPGBot.UI/docs/App.xaml.md
@@ -1,0 +1,15 @@
+# App.xaml
+
+Defines WPF application-level resources and the startup window.
+
+Summary
+- Standard WPF Application markup.
+- Sets StartupUri to MainWindow.xaml.
+- Central place to add resource dictionaries, styles, and theme resources if needed.
+
+Why it matters
+- Keeps global styles consistent across the UI.
+- Controls which window is launched first.
+
+Tips
+- Add global styles or merged dictionaries here if you want cohesive theming across all views.

--- a/EpicRPGBot.UI/docs/BotEngine.cs.md
+++ b/EpicRPGBot.UI/docs/BotEngine.cs.md
@@ -1,0 +1,69 @@
+# BotEngine.cs
+
+Purpose
+- Core automation engine that drives Discord through WebView2 DevTools. 
+- Sends commands, manages cooldown timers, reads last messages, and publishes simple events for the UI.
+
+Key Responsibilities
+- Start/Stop the automation loop
+- Send commands using WebView2 DevTools (Input.insertText and key events) into the real message composer
+- Keep and use cooldown timers via DispatcherTimer (hunt/work/farm)
+- Poll the DOM for the latest message for lightweight reactions
+- Raise UI events for logging and “last messages” panel
+
+Public API
+- bool IsRunning
+  - Indicates whether the engine is currently running.
+- void Start()
+  - Starts automation timers, chooses work command by area, and schedules an opening salvo (hunt/work[/farm]).
+  - Note: “rpg cd” is not sent here; the UI calls SendImmediateAsync before Start to ensure an instant send on button click.
+- void Stop()
+  - Stops all timers and marks the engine as stopped.
+- Task<bool> SendImmediateAsync(string text)
+  - Sends a command immediately, publishes OnCommandSent, and returns success/failure.
+
+Events
+- OnEngineStarted
+- OnEngineStopped
+- OnCommandSent(string cmd)
+- OnMessageSeen(string text)
+
+How sending works
+1) FocusComposerAsync()
+   - Finds the Discord message composer reliably (bottom-most visible role="textbox" / data-slate-editor).
+   - Scrolls to, clicks, focuses, and places caret at the end to avoid the header search box.
+2) DevTools send
+   - Input.insertText to type the text
+   - Input.dispatchKeyEvent for Enter (keyDown + keyUp)
+   - Fallback: if DevTools fails, use document.execCommand insertText + dispatch KeyboardEvent(Enter)
+
+Timers
+- _huntT: Hunt cooldown
+- _workT: Work cooldown (chop/axe/bowsaw/chainsaw chosen by Area)
+- _farmT: Farm cooldown (enabled for Area >= 4)
+- _checkMessageT: Polls for the last message to drive simple reactions
+
+DOM polling (CheckLastMessageAsync)
+- Reads the last li[id^='chat-messages-'] item’s innerText and id
+- Emits OnMessageSeen when a new message id appears (simple rolling detection)
+
+Opening salvo
+- The UI sends “rpg cd” immediately (via Start button) using SendImmediateAsync
+- Start() then waits ~2s and sends hunt, wait, work, wait, and optionally farm
+
+Notes
+- The composer focus and DevTools strategy avoid typing into Discord’s header search.
+- If Discord markup changes, FocusComposerAsync uses broad selectors and a fallback path.
+- Keep WebView2 runtime up to date for compatibility.
+
+Configuration/Cooldowns
+- Area, HuntCooldown, WorkCooldown, FarmCooldown are passed in from the UI.
+- Work command is derived from Area:
+  - 1–2: rpg chop
+  - 3–5: rpg axe
+  - 6–8: rpg bowsaw
+  - 9–13: rpg chainsaw
+
+Troubleshooting
+- If messages go into the header search, update to the latest build; the engine uses a bottom-most textbox heuristic and DevTools insertText.
+- If sending fails temporarily, the fallback path (execCommand) kicks in automatically.

--- a/EpicRPGBot.UI/docs/Env.cs.md
+++ b/EpicRPGBot.UI/docs/Env.cs.md
@@ -1,0 +1,16 @@
+# Env.cs
+
+Simple .env loader used by the UI to mirror the console app’s configuration approach.
+
+Responsibilities
+- Load(): Reads a .env file from repository root (same folder where the solution resides) into process environment variables (only for keys that are not already set).
+- Get(key, fallback): Retrieves a value from environment variables with a string fallback.
+
+Used keys (current UI)
+- DISCORD_CHANNEL_URL: Target Discord channel URL to open in WebView2.
+- AREA: Integer used by BotEngine to choose work command (chop/axe/bowsaw/chainsaw).
+- HUNT_COOLDOWN / WORK_COOLDOWN / FARM_COOLDOWN: Millisecond cooldowns used by timers.
+
+Notes
+- The loader is intentionally minimal and tolerant of blank lines and comments.
+- If a key is present in the OS env already, that value “wins” and .env does not override it.

--- a/EpicRPGBot.UI/docs/EpicRPGBot.UI.csproj.md
+++ b/EpicRPGBot.UI/docs/EpicRPGBot.UI.csproj.md
@@ -1,0 +1,20 @@
+# EpicRPGBot.UI.csproj
+
+Overview
+- WPF desktop app targeting .NET Framework 4.8.
+- Uses WebView2 (Evergreen runtime) for embedding Discord.
+- Builds as x64 with a persistent WebView2 user data folder.
+
+Key Properties
+- TargetFramework: net48
+- UseWPF: true
+- PlatformTarget: x64
+- RuntimeIdentifier: win-x64
+- CopyLocalLockFileAssemblies: true (ensures referenced libs are copied locally)
+- PackageReference: Microsoft.Web.WebView2 (1.0.2792.45), Microsoft.NETFramework.ReferenceAssemblies (1.0.3)
+
+Notes
+- Build and run:
+  - dotnet build EpicRPGBotCSharp.sln -c Debug
+  - dotnet run --project EpicRPGBot.UI -c Debug
+- Requires WebView2 Evergreen Runtime installed on Windows.

--- a/EpicRPGBot.UI/docs/InMemoryLog.cs.md
+++ b/EpicRPGBot.UI/docs/InMemoryLog.cs.md
@@ -1,0 +1,47 @@
+# InMemoryLog.cs
+
+Purpose
+- Lightweight, in-memory console log for the UI.
+- Exposes an ObservableCollection<LogEntry> for direct data binding in WPF (ConsoleList.ItemsSource = _log.Items).
+
+Key Types
+- LogEntry (Models/LogEntry.cs)
+  - Timestamp (DateTime)
+  - Kind (string) — e.g., "info", "warn", "error", "engine"
+  - Message (string)
+
+Public API
+- ObservableCollection<LogEntry> Items
+  - Bind this to a ListBox/ItemsControl in XAML to render the console-like view.
+- int MaxItems (default: 500)
+  - Rolling cap to prevent unbounded memory growth.
+- void Append(LogEntry entry)
+  - Appends a new entry and prunes if over MaxItems.
+- void Info(string message)
+- void Warn(string message)
+- void Error(string message)
+- void Engine(string message)
+  - Convenience methods that create a LogEntry with the given kind.
+
+Threading Notes
+- Items is a WPF-bound ObservableCollection and must be updated on the UI thread.
+- Use UiDispatcher.OnUI(() => _log.Info("...")) if you are appending from a non-UI context.
+
+Typical Usage
+- In MainWindow.xaml.cs:
+  - ConsoleList.ItemsSource = _log.Items
+  - _log.Info("Start button clicked");
+  - _log.Engine("Engine started (timers running; hunt/work[/farm] scheduled)");
+
+Behavior
+- Each append creates a LogEntry with a UTC timestamp.
+- When the collection size exceeds MaxItems, the oldest items are removed.
+
+Extending
+- Add more convenience methods if you need additional categories (e.g., Debug).
+- Consider persisting to disk if you need historical logs (this class intentionally keeps only an in-memory rolling buffer).
+
+Related Files
+- Models/LogEntry.cs — log record model.
+- Services/UiDispatcher.cs — helper to marshal actions onto the WPF UI thread.
+- MainWindow.xaml(.cs) — binds ConsoleList.ItemsSource to InMemoryLog.Items and writes log lines on user actions/engine events.

--- a/EpicRPGBot.UI/docs/LastMessagesBuffer.cs.md
+++ b/EpicRPGBot.UI/docs/LastMessagesBuffer.cs.md
@@ -1,0 +1,44 @@
+# LastMessagesBuffer.cs
+
+Purpose
+- Maintains a rolling buffer of the most recent N chat messages for display in the left “Stats” panel.
+- Exposes an ObservableCollection<MessageItem> for direct WPF binding.
+
+Key Types
+- MessageItem (Models/MessageItem.cs)
+  - Timestamp (DateTime)
+  - Text (string)
+
+Public API
+- LastMessagesBuffer(int capacity)
+  - Capacity defines how many recent messages are kept (UI uses 5 by default).
+- ObservableCollection<MessageItem> Items
+  - Bind directly to a ListBox/ItemsControl (e.g., StatsList.ItemsSource).
+- void Add(string text)
+  - Pushes a new message into the buffer with current UTC timestamp.
+  - Automatically trims the oldest entries when over capacity.
+- void Clear()
+  - Empties the collection.
+
+Threading Notes
+- Items is an ObservableCollection bound to the WPF UI. Append on the UI thread.
+- If adding from timers or async background calls, marshal to UI with UiDispatcher.OnUI(() => buffer.Add(...)).
+
+Typical Usage
+- In MainWindow.xaml.cs:
+  - private readonly LastMessagesBuffer _last = new LastMessagesBuffer(5);
+  - StatsList.ItemsSource = _last.Items;
+  - When new text is detected (via DOM polling or engine events), call _last.Add(text) on the UI thread.
+
+Behavior
+- Keeps at most Capacity messages.
+- Adds newest message to the end of the observable collection; the ListBox shows them in order.
+
+Extending
+- Consider adding a filter or message source tag if you want to distinguish system vs. user vs. bot messages.
+- Capacity is fixed per instance; add a SetCapacity method if you want runtime configuration.
+
+Related Files
+- Models/MessageItem.cs — data model with timestamp + text.
+- Services/UiDispatcher.cs — ensures updates happen on the WPF UI thread.
+- MainWindow.xaml(.cs) — binds the left Stats ListBox to LastMessagesBuffer.Items.

--- a/EpicRPGBot.UI/docs/MainWindow.xaml.cs.md
+++ b/EpicRPGBot.UI/docs/MainWindow.xaml.cs.md
@@ -1,0 +1,72 @@
+# MainWindow.xaml.cs
+
+Purpose
+- WPF code-behind for the main window. 
+- Owns UI state (left Stats/Console lists, settings text boxes) and interacts with BotEngine.
+- Hosts and initializes WebView2, navigates to the Discord channel, handles interstitials.
+- Polls the page for the last chat message to populate the Stats pane.
+
+Key UI Elements (by name)
+- Web (WebView2): Central browser surface for Discord.
+- StatsList (ListBox/ItemsControl): Displays rolling last 5 messages.
+- ConsoleList (ListBox/ItemsControl): Console-like logs of actions.
+- ChannelUrlBox, UseAtMeFallback: Navigation target controls.
+- AreaBox, HuntCdBox, WorkCdBox, FarmCdBox: Bot parameters.
+- StartBtn, StopBtn: Bot control buttons.
+- StatsTabBtn, ConsoleTabBtn: Toggle which left panel is visible.
+- StatsPanel, ConsolePanel: Left-side containers, toggled visible/hidden.
+
+Initialization flow
+1) MainWindow_Loaded():
+   - Env.Load() and seed UI values from .env (DISCORD_CHANNEL_URL, AREA, HUNT/WORK/FARM_COOLDOWN).
+   - Bind StatsList to LastMessagesBuffer.Items and ConsoleList to InMemoryLog.Items.
+   - Initialize WebView2 with a persistent user data folder under LocalAppData/EpicRPGBot.UI/WebView2.
+   - Navigate to channel URL (from box or fallback to @me).
+   - Start polling the last message every 2 seconds.
+
+WebView2 setup
+- CoreWebView2 settings enable context menus, dev tools, and zoom control.
+- NavigationCompleted triggers an interstitial click helper that presses “Open/Continue in browser” prompts when present.
+
+Discord interstitial helper
+- ClickInterstitialsAsync() scans visible text for “Open Discord in your browser”, “Continue to Discord”, or “Continue in browser” and clicks them if found.
+
+Polling last messages
+- StartPollingLastMessage() uses a DispatcherTimer to:
+  - Evaluate a small JS snippet to read the last li[id^='chat-messages-'] element’s innerText.
+  - Deduplicate on the UI side to avoid re-adding the same last line.
+  - Append to the rolling LastMessagesBuffer (size 5) via UiDispatcher.
+
+Start/Stop behavior
+- StartBtn_Click (async):
+  - If a bot engine instance exists and IsRunning == true, ignore the click (no duplicate engines or “rpg cd” sends).
+  - Reads area/cooldowns from text boxes.
+  - Creates a new BotEngine with those parameters.
+  - Immediately sends “rpg cd” via engine.SendImmediateAsync("rpg cd") and logs success/failure into the Console view.
+  - Calls engine.Start() to begin timers and the opening hunt/work[/farm] sequence.
+- StopBtn_Click:
+  - Calls engine.Stop() and logs the stop event.
+
+Left sidebar toggle
+- StatsTabBtn_Click(), ConsoleTabBtn_Click():
+  - Toggle visibility of StatsPanel and ConsolePanel.
+
+Helpers
+- GetChannelUrl(): resolves channel URL from textbox with optional @me fallback.
+- UnquoteJson(): utility to unescape the string result from ExecuteScriptAsync.
+- SafeInt(): simple parser with default.
+
+Data sources (bound in code-behind)
+- InMemoryLog: appends Engine/Info log lines with timestamps; bound to ConsoleList.
+- LastMessagesBuffer: rolling last 5 chat messages with timestamps; bound to StatsList.
+
+Notes
+- The UI currently polls last messages on its own. The engine also emits OnMessageSeen, which can be wired for richer behavior in the future.
+- If Discord markup changes, the page polling might require a small selector update (li[id^='chat-messages-']). The engine’s internal scanning uses a similar pattern.
+
+Troubleshooting
+- If Start does nothing:
+  - Ensure WebView2 is initialized (InitHint is hidden).
+  - Check that Discord is loaded and you are authenticated.
+- If no messages appear in Stats:
+  - Confirm the channel actually has messages; the polling appends only when the last item changes.

--- a/EpicRPGBot.UI/docs/MainWindow.xaml.md
+++ b/EpicRPGBot.UI/docs/MainWindow.xaml.md
@@ -1,0 +1,23 @@
+# MainWindow.xaml
+
+Defines the 3-column layout of the EpicRPGBot.UI application.
+
+Layout
+- Columns
+  - Left: 260px sidebar containing the Stats/Console toggle and two content panels (StatsPanel, ConsolePanel).
+  - Center: WebView2 host (Discord) with a small header row containing navigation buttons.
+  - Right: 300px settings panel including channel URL, bot parameters and Start/Stop buttons.
+- Key named elements
+  - StatsTabBtn / ConsoleTabBtn: toggle which panel is visible in the left column.
+  - StatsPanel: a ListBox (StatsList) bound to the rolling 5 last messages.
+  - ConsolePanel: a ListBox (ConsoleList) bound to log entries.
+  - Web: WebView2 control for Discord.
+  - InitHint: simple overlay text shown during WebView2 initialization.
+  - ChannelUrlBox, UseAtMeFallback: channel navigation controls.
+  - AreaBox, HuntCdBox, WorkCdBox, FarmCdBox: bot parameter inputs.
+  - StartBtn, StopBtn: engine controls.
+
+Notes
+- Uses a dark theme palette aligned loosely with Discord.
+- Top row in the center provides Reload and “Go To Channel” actions.
+- XAML names are referenced in MainWindow.xaml.cs for code-behind logic and bindings.

--- a/EpicRPGBot.UI/docs/UiDispatcher.cs.md
+++ b/EpicRPGBot.UI/docs/UiDispatcher.cs.md
@@ -1,0 +1,21 @@
+# UiDispatcher.cs
+
+Small helper to marshal actions onto the WPF UI thread. Prevents InvalidOperationException when updating bound collections from background code.
+
+Summary
+- Static class with a single method OnUI(Action action).
+- If Application.Current?.Dispatcher is available:
+  - If already on UI thread: invoke synchronously.
+  - Otherwise: BeginInvoke at DispatcherPriority.Background.
+- If no dispatcher (during app shutdown/edge cases), runs the action directly as a best-effort fallback.
+
+Key API
+- public static void OnUI(Action action)
+
+Typical Usage
+- Updating ObservableCollection bound to UI from timers, WebView2 callbacks, or background tasks:
+  UiDispatcher.OnUI(() => MyCollection.Add(item));
+
+Notes
+- Keeps UI responsive by using BeginInvoke.
+- Safe to call frequently; avoid long-running work inside the action (do that off-UI, then marshal only the minimal UI update).

--- a/EpicRPGBotCSHARP/docs/Program.cs.md
+++ b/EpicRPGBotCSHARP/docs/Program.cs.md
@@ -1,0 +1,34 @@
+# EpicRPGBotCSHARP/Program.cs
+
+Legacy console automation for EpicRPG using Selenium/WebDriver. The new WPF UI (EpicRPGBot.UI) replaces browser automation with WebView2 DevTools, but this console app documents the original flow and can be used as reference.
+
+High‑level responsibilities
+- LoadEnv(): Reads .env into process for configuration (channel URL, cooldowns, area).
+- Browser init: Launches a Chromium browser via Selenium (keeps session and navigates to the target Discord channel).
+- ClickInterstitials(): Dismisses Discord interstitial prompts (Open/Continue in Browser etc.).
+- SendMessage()/SendCommand(): Types commands into the channel input and submits them with Enter.
+- CheckLastMessage(): Polls the DOM for the latest message to drive logic and cooldown handling.
+- EventCheck(): Parses message text for specific triggers (e.g., help, farm/work variations, lootbox/boss events) and responds accordingly.
+- StartBot()/Stop loop: Orchestrates initial opening salvo (cd → hunt → work → farm if area >= 4) and continuous timers for hunt/work/farm.
+
+Core config keys (via .env)
+- DISCORD_CHANNEL_URL: Discord channel to automate.
+- AREA: Affects which “work” command to use:
+  - 1–2: rpg chop
+  - 3–5: rpg axe
+  - 6–8: rpg bowsaw
+  - 9–13: rpg chainsaw
+- HUNT_COOLDOWN / WORK_COOLDOWN / FARM_COOLDOWN: timer intervals in milliseconds.
+
+Key differences vs UI engine
+- Console uses Selenium to automate an external browser; the UI uses WebView2 DevTools inside the app.
+- The UI engine focuses the bottom composer reliably and uses DevTools Input.insertText and key dispatch for Enter; this avoids typing into the header search.
+- The UI sends “rpg cd” immediately on Start and prevents double‑start; the console app’s StartBot was the original reference for the opening salvo.
+
+Migration notes
+- The UI (BotEngine.cs) ports SendMessage/SendCommand/CheckLastMessage logic using WebView2 ExecuteScript/DevTools with DispatcherTimers.
+- Any future event responses added to Program.cs should be mirrored into BotEngine.EventCheck to keep behavior consistent.
+
+Troubleshooting (legacy)
+- If Discord layout changes, Selenium selectors may break. The UI engine’s composer heuristics and DevTools path are more robust for Discord’s React/Slate editor.
+- Ensure the correct Chrome driver/browser version when running the console app.

--- a/EpicRPGBotCSharp.sln
+++ b/EpicRPGBotCSharp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EpicRPGBotCSharp", "EpicRPGBotCSHARP\EpicRPGBotCSharp.csproj", "{D47BD117-13C9-4EC1-AD34-6626B86E5645}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EpicRPGBot.UI", "EpicRPGBot.UI\EpicRPGBot.UI.csproj", "{A6F1C6F9-9B77-4B54-9E5D-7C7C69E3B9B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{D47BD117-13C9-4EC1-AD34-6626B86E5645}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D47BD117-13C9-4EC1-AD34-6626B86E5645}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D47BD117-13C9-4EC1-AD34-6626B86E5645}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6F1C6F9-9B77-4B54-9E5D-7C7C69E3B9B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6F1C6F9-9B77-4B54-9E5D-7C7C69E3B9B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6F1C6F9-9B77-4B54-9E5D-7C7C69E3B9B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6F1C6F9-9B77-4B54-9E5D-7C7C69E3B9B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
UI integration

Summary
This PR adds a new WPF (.NET Framework 4.8) UI that embeds Discord via WebView2 and moves the bot automation directly into the UI (no Selenium/Chrome instance). It also replaces the root README with an English, UI‑focused guide and adds per‑file documentation for the UI and console components.

Highlights
- New WPF UI project EpicRPGBot.UI (WebView2-based)
- In-app automation engine using WebView2 DevTools (Input.insertText + key events)
- Reliable composer focus (avoids typing into the Discord header search)
- Start Bot now:
  - Immediately sends “rpg cd”
  - Then continues with hunt/work/farm opening salvo based on Area
  - Timers continue sending commands on cooldown
- Left sidebar with two tabs:
  - Stats: rolling last 5 messages (with timestamps)
  - Console: structured logs (engine start/stop, commands sent)
- Persistent WebView2 profile for Discord login
- Clicks common interstitials automatically after navigation
- README overhaul and English documentation for each code file

What’s included
- EpicRPGBot.UI/
  - App.xaml, App.xaml.cs
  - MainWindow.xaml, MainWindow.xaml.cs
  - BotEngine.cs (WebView2 automation + timers + event hooks)
  - Env.cs (simple .env loader)
  - Services: InMemoryLog, LastMessagesBuffer, UiDispatcher
  - README.md (UI usage, build and troubleshooting)
  - docs/ (per-file docs)
    - App.xaml.md
    - EpicRPGBot.UI.csproj.md
    - MainWindow.xaml.md
    - MainWindow.xaml.cs.md
    - BotEngine.cs.md
    - InMemoryLog.cs.md
    - LastMessagesBuffer.cs.md
    - UiDispatcher.cs.md
    - Env.cs.md
- EpicRPGBotCSHARP/docs/Program.cs.md (console bot reference)
- Root README.md replaced with English UI-focused README

Behavioral notes
- Composer focus: Engine picks the bottom-most visible role="textbox" (or data-slate-editor) element and focuses it before sending text via DevTools; falls back to execCommand if needed.
- Start dedupe: Clicking Start while running is ignored (no duplicate ‘rpg cd’ and no double timers).
- Message polling: The UI polls last message text and records into a rolling buffer for the Stats tab.

How to run
- Build: dotnet build EpicRPGBotCSharp.sln -c Debug
- Run UI: dotnet run --project EpicRPGBot.UI -c Debug
- Ensure WebView2 Runtime is installed (winget install Microsoft.EdgeWebView2Runtime)
- Configure .env with DISCORD_CHANNEL_URL and cooldowns (see README)

Screenshots
- Not included yet; structure allows adding under EpicRPGBot.UI/docs/img and referencing them in README.

Risks / follow-ups
- Discord DOM can change; selectors are resilient but may require updates.
- Future: expose engine events to the left panels directly (currently basic logging/polling is in place).
- Optional: add more command customization and richer stats.

License
- MIT (project default).