### PR TITLE
Better Settings: Initialize cooldowns (hunt/adventure/farm/work)

### DIFF
--- a/EpicRPGBot.UI/MainWindow.xaml
+++ b/EpicRPGBot.UI/MainWindow.xaml
@@ -141,7 +141,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="daily" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="DailyCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -150,7 +150,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="weekly" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="WeeklyCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -159,7 +159,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="lootbox" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="LootboxCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -168,7 +168,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="card hand" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="CardHandCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,8">
@@ -177,7 +177,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="vote" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="VoteCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <!-- Experience -->
@@ -189,7 +189,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="hunt" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="HuntCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -198,7 +198,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="adventure" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="AdventureCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -207,7 +207,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="training" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="TrainingCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -216,7 +216,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="duel" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="DuelCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,8">
@@ -225,7 +225,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="quest | epic quest" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="QuestCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <!-- Progress -->
@@ -237,7 +237,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="chop | fish | pickup | mine" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="WorkCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -246,7 +246,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="farm" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="FarmCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -255,7 +255,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="horse breeding | horse race" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="HorseCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,2">
@@ -264,7 +264,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="arena" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="ArenaCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                         <Grid Margin="0,2,0,0">
@@ -273,7 +273,7 @@
                                 <ColumnDefinition Width="120"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Text="dungeon | miniboss" Foreground="#ddd"/>
-                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                            <TextBlock Name="DungeonCdText" Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
                         </Grid>
 
                     </StackPanel>

--- a/EpicRPGBot.UI/MainWindow.xaml
+++ b/EpicRPGBot.UI/MainWindow.xaml
@@ -126,6 +126,158 @@
                         <Button Name="StopBtn" Content="Stop Bot" Padding="12,4" Click="StopBtn_Click"/>
                     </StackPanel>
 
+                    <Separator Background="#2f3136" Margin="0,12,0,8"/>
+
+                    <TextBlock Text="Cooldowns (visual)" Foreground="#ddd" FontWeight="SemiBold" Margin="0,0,0,6"/>
+
+                    <StackPanel Name="CooldownsPanel" Margin="0,0,0,8">
+
+                        <!-- Rewards -->
+                        <TextBlock Text="Rewards" Foreground="#ccc" Margin="0,6,0,2"/>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="daily" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="weekly" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="lootbox" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="card hand" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="vote" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <!-- Experience -->
+                        <TextBlock Text="Experience" Foreground="#ccc" Margin="0,6,0,2"/>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="hunt" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="adventure" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="training" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="duel" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="quest | epic quest" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <!-- Progress -->
+                        <TextBlock Text="Progress" Foreground="#ccc" Margin="0,6,0,2"/>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="chop | fish | pickup | mine" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="farm" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="horse breeding | horse race" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="arena" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                        <Grid Margin="0,2,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="120"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="dungeon | miniboss" Foreground="#ddd"/>
+                            <TextBlock Grid.Column="1" Text="00h 00m 00s" Foreground="#aaa" HorizontalAlignment="Right"/>
+                        </Grid>
+
+                    </StackPanel>
+                    
                 </StackPanel>
             </ScrollViewer>
         </Border>

--- a/EpicRPGBot.UI/MainWindow.xaml.cs
+++ b/EpicRPGBot.UI/MainWindow.xaml.cs
@@ -48,6 +48,7 @@ namespace EpicRPGBot.UI
             WorkCdBox.Text = Env.Get("WORK_COOLDOWN", "99000");
             FarmCdBox.Text = Env.Get("FARM_COOLDOWN", "196000");
 
+
             // Bind left panels
             StatsList.ItemsSource = _last.Items;
             ConsoleList.ItemsSource = _log.Items;
@@ -56,6 +57,15 @@ namespace EpicRPGBot.UI
             // Cache named elements for tabs/stats to avoid compile-time field generation issues
             _lastMessagesPanel = (System.Windows.Controls.Grid)FindName("LastMessagesPanel");
             _huntCountText = (System.Windows.Controls.TextBlock)FindName("HuntCountText");
+
+            // Load persisted initialization ms (defaults if missing)
+            try
+            {
+                HuntCdBox.Text = LoadCooldownMsOrDefault("hunt_ms", 61000).ToString();
+                WorkCdBox.Text = LoadCooldownMsOrDefault("work_ms", SafeInt(WorkCdBox.Text, 99000)).ToString();
+                FarmCdBox.Text = LoadCooldownMsOrDefault("farm_ms", SafeInt(FarmCdBox.Text, 196000)).ToString();
+            }
+            catch { }
 
             // Setup cooldown label mapping + ticking
             InitCooldownTracking();
@@ -207,11 +217,67 @@ namespace EpicRPGBot.UI
         private async Task<bool> SendMessageAsync(string message)
         {
             if (Web.CoreWebView2 == null) return false;
-            string escaped = (message ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n");
-            string js = $@"
+
+            // Focus the real Discord composer (bottom-most visible textbox)
+            string focusJs = @"
+(function(){
+  let candidates = Array.from(document.querySelectorAll(
+    'div[role=""textbox""][data-slate-editor=""true""], ' +
+    'div[aria-label^=""Message""][role=""textbox""], ' +
+    'div[aria-label*=""Message""][role=""textbox""]'
+  ));
+  if (candidates.length === 0) {
+    candidates = Array.from(document.querySelectorAll('div[role=""textbox""], div[contenteditable=""true""]'));
+  }
+  if (candidates.length === 0) return false;
+  candidates.sort((a,b)=>a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+  const editor = candidates[candidates.length - 1];
+  try { editor.scrollIntoView({block:'center'}); } catch(e) {}
+  try { editor.click(); } catch(e) {}
+  try { editor.focus(); } catch(e) {}
+  return true;
+})();";
+            try { await Web.CoreWebView2.ExecuteScriptAsync(focusJs); } catch { }
+
+            // Prefer DevTools to type and press Enter
+            try
+            {
+                string text = (message ?? string.Empty)
+                    .Replace("\\", "\\\\")
+                    .Replace("\"", "\\\"")
+                    .Replace("\r", "")
+                    .Replace("\n", "\\n");
+
+                await Web.CoreWebView2.CallDevToolsProtocolMethodAsync(
+                    "Input.insertText",
+                    $"{{\"text\":\"{text}\"}}"
+                );
+
+                const string keyDown = "{\"type\":\"keyDown\",\"key\":\"Enter\",\"code\":\"Enter\",\"windowsVirtualKeyCode\":13,\"nativeVirtualKeyCode\":13}";
+                const string keyUp   = "{\"type\":\"keyUp\",\"key\":\"Enter\",\"code\":\"Enter\",\"windowsVirtualKeyCode\":13,\"nativeVirtualKeyCode\":13}";
+
+                await Web.CoreWebView2.CallDevToolsProtocolMethodAsync("Input.dispatchKeyEvent", keyDown);
+                await Web.CoreWebView2.CallDevToolsProtocolMethodAsync("Input.dispatchKeyEvent", keyUp);
+                return true;
+            }
+            catch
+            {
+                // Fallback to execCommand if DevTools path fails
+                string escaped = (message ?? string.Empty).Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n");
+                string js = $@"
 (async () => {{
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-  const editor = document.querySelector(""div[role='textbox']"") || document.querySelector(""[contenteditable='true']"");
+  let candidates = Array.from(document.querySelectorAll(
+    'div[role=""textbox""][data-slate-editor=""true""], ' +
+    'div[aria-label^=""Message""][role=""textbox""], ' +
+    'div[aria-label*=""Message""][role=""textbox""]'
+  ));
+  if (candidates.length === 0) {{
+    candidates = Array.from(document.querySelectorAll('div[role=""textbox""], div[contenteditable=""true""]'));
+  }}
+  if (candidates.length === 0) return false;
+  candidates.sort((a,b)=>a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+  const editor = candidates[candidates.length - 1];
   if (!editor) return false;
   editor.focus();
   try {{
@@ -225,12 +291,13 @@ namespace EpicRPGBot.UI
   }} catch (e) {{ return false; }}
 }})();
 ";
-            try
-            {
-                var r = (await Web.CoreWebView2.ExecuteScriptAsync(js))?.Trim();
-                return string.Equals(r, "true", StringComparison.OrdinalIgnoreCase);
+                try
+                {
+                    var r = (await Web.CoreWebView2.ExecuteScriptAsync(js))?.Trim();
+                    return string.Equals(r, "true", StringComparison.OrdinalIgnoreCase);
+                }
+                catch { return false; }
             }
-            catch { return false; }
         }
 
         private void ReloadBtn_Click(object sender, RoutedEventArgs e)
@@ -246,6 +313,78 @@ namespace EpicRPGBot.UI
         private async void GoChannelBtn_Click(object sender, RoutedEventArgs e)
         {
             await NavigateToChannelAsync(GetChannelUrl());
+        }
+
+        private async void InitBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _log.Info("Inicialize sequence started");
+
+            if (Web.CoreWebView2 == null)
+            {
+                _log.Info("WebView2 not ready");
+                return;
+            }
+
+            // Sequential initialization per request:
+            // For each: send action, wait 2s; send 'rpg cd', wait 1s + extra 1s; parse cd; add (2+1+1)=4s overhead; save; update UI ms; wait 3s before next
+            const int actionDelayMs = 2000;           // after action
+            const int afterCdDelayMs = 1000;          // after 'rpg cd'
+            const int extraLagMs = 1000;              // additional safety before computing baseline
+            const int overheadMs = actionDelayMs + afterCdDelayMs + extraLagMs; // 4000 total
+            const int betweenCommandsMs = 3000;
+
+            // Hunt
+            await InitializeOneAsync(
+                canonical: "hunt",
+                sendAction: "rpg hunt h",
+                defaultMs: 61000,
+                applyMsToUi: (ms) => HuntCdBox.Text = ms.ToString(),
+                actionDelayMs: actionDelayMs,
+                afterCdDelayMs: afterCdDelayMs,
+                extraLagMs: extraLagMs,
+                overheadMs: overheadMs
+            );
+            await Task.Delay(betweenCommandsMs);
+
+            // Adventure (persist; no textbox to show)
+            await InitializeOneAsync(
+                canonical: "adventure",
+                sendAction: "rpg adventure",
+                defaultMs: 61000,
+                applyMsToUi: null,
+                actionDelayMs: actionDelayMs,
+                afterCdDelayMs: afterCdDelayMs,
+                extraLagMs: extraLagMs,
+                overheadMs: overheadMs
+            );
+            await Task.Delay(betweenCommandsMs);
+
+            // Farm
+            await InitializeOneAsync(
+                canonical: "farm",
+                sendAction: "rpg farm",
+                defaultMs: SafeInt(FarmCdBox.Text, 196000),
+                applyMsToUi: (ms) => FarmCdBox.Text = ms.ToString(),
+                actionDelayMs: actionDelayMs,
+                afterCdDelayMs: afterCdDelayMs,
+                extraLagMs: extraLagMs,
+                overheadMs: overheadMs
+            );
+            await Task.Delay(betweenCommandsMs);
+
+            // Work (explicit chainsaw as requested)
+            await InitializeOneAsync(
+                canonical: "work",
+                sendAction: "rpg chainsaw",
+                defaultMs: SafeInt(WorkCdBox.Text, 99000),
+                applyMsToUi: (ms) => WorkCdBox.Text = ms.ToString(),
+                actionDelayMs: actionDelayMs,
+                afterCdDelayMs: afterCdDelayMs,
+                extraLagMs: extraLagMs,
+                overheadMs: overheadMs
+            );
+
+            _log.Info("Inicialize sequence finished");
         }
 
         private async void StartBtn_Click(object sender, RoutedEventArgs e)
@@ -300,6 +439,146 @@ namespace EpicRPGBot.UI
         private int SafeInt(string s, int def)
         {
             return int.TryParse(s, out var v) ? v : def;
+        }
+
+        // --------- Persisted initialization (concept for Hunt only) ---------
+
+        private static string GetSettingsFilePath()
+        {
+            var root = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EpicRPGBot.UI", "settings");
+            Directory.CreateDirectory(root);
+            return Path.Combine(root, "cooldowns.ini");
+        }
+
+        private int LoadHuntCooldownMsOrDefault()
+        {
+            try
+            {
+                var path = GetSettingsFilePath();
+                if (File.Exists(path))
+                {
+                    foreach (var line in File.ReadAllLines(path))
+                    {
+                        var t = line.Trim();
+                        if (t.StartsWith("hunt_ms=", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var val = t.Substring("hunt_ms=".Length).Trim();
+                            if (int.TryParse(val, out var ms) && ms > 0) return ms;
+                        }
+                    }
+                }
+            }
+            catch { }
+            // Default if not initialized: 1 minute 1 second
+            return 61000;
+        }
+
+        private void SaveHuntCooldownMs(int ms)
+        {
+            try
+            {
+                var path = GetSettingsFilePath();
+                File.WriteAllText(path, $"hunt_ms={ms}{Environment.NewLine}");
+            }
+            catch { }
+        }
+
+        // --------- Persisted initialization (generic helpers) ---------
+
+        private int LoadCooldownMsOrDefault(string key, int @default)
+        {
+            try
+            {
+                var path = GetSettingsFilePath();
+                if (File.Exists(path))
+                {
+                    foreach (var line in File.ReadAllLines(path))
+                    {
+                        var t = line.Trim();
+                        if (t.StartsWith(key + "=", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var val = t.Substring((key + "=").Length).Trim();
+                            if (int.TryParse(val, out var ms) && ms > 0) return ms;
+                        }
+                    }
+                }
+            }
+            catch { }
+            return @default;
+        }
+
+        private void SaveCooldownMs(string key, int ms)
+        {
+            try
+            {
+                var path = GetSettingsFilePath();
+                var lines = new List<string>();
+                var written = false;
+
+                if (File.Exists(path))
+                {
+                    foreach (var line in File.ReadAllLines(path))
+                    {
+                        if (line.TrimStart().StartsWith(key + "=", StringComparison.OrdinalIgnoreCase))
+                        {
+                            lines.Add($"{key}={ms}");
+                            written = true;
+                        }
+                        else
+                        {
+                            lines.Add(line);
+                        }
+                    }
+                }
+
+                if (!written)
+                {
+                    lines.Add($"{key}={ms}");
+                }
+
+                File.WriteAllLines(path, lines);
+            }
+            catch { }
+        }
+
+        private async Task InitializeOneAsync(
+            string canonical,
+            string sendAction,
+            int defaultMs,
+            Action<int> applyMsToUi,
+            int actionDelayMs,
+            int afterCdDelayMs,
+            int extraLagMs,
+            int overheadMs)
+        {
+            _log.Info($"Inicialize: {canonical} via '{sendAction}'");
+
+            var sent1 = await SendMessageAsync(sendAction);
+            if (!sent1) _log.Info($"Failed to send '{sendAction}'");
+
+            await Task.Delay(actionDelayMs);
+
+            var sentCd = await SendMessageAsync("rpg cd");
+            if (!sentCd) _log.Info("Failed to send 'rpg cd'");
+
+            await Task.Delay(afterCdDelayMs + extraLagMs);
+
+            var last = await GetLastMessageTextAsync();
+            if (!string.IsNullOrWhiteSpace(last))
+            {
+                TryParseCooldowns(last);
+            }
+
+            int baseMs = defaultMs;
+            if (_cooldowns.TryGetValue(canonical, out var entry))
+            {
+                if (entry?.Remaining.HasValue == true)
+                    baseMs = (int)Math.Max(0, entry.Remaining.Value.TotalMilliseconds) + overheadMs;
+            }
+
+            SaveCooldownMs($"{canonical}_ms", baseMs);
+            applyMsToUi?.Invoke(baseMs);
+            _log.Info($"Inicialize: {canonical} cooldown set to {baseMs} ms (saved)");
         }
 
         // ------------------------- Cooldowns (visual -> functional) -------------------------

--- a/EpicRPGBot.UI/MainWindow.xaml.cs
+++ b/EpicRPGBot.UI/MainWindow.xaml.cs
@@ -7,6 +7,10 @@ using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using EpicRPGBot.UI.Services;
 using EpicRPGBot.UI.Models;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Linq;
+using System.Windows.Controls;
 
 namespace EpicRPGBot.UI
 {
@@ -23,6 +27,11 @@ namespace EpicRPGBot.UI
         private System.Windows.Controls.Grid _lastMessagesPanel;
         private System.Windows.Controls.TextBlock _huntCountText;
 
+        // Cooldown tracking
+        private DispatcherTimer _cooldownTimer;
+        private readonly Dictionary<string, CooldownEntry> _cooldowns = new();
+        private readonly Dictionary<string, string> _aliasToCanonical = new();
+        
         public MainWindow()
         {
             InitializeComponent();
@@ -48,6 +57,9 @@ namespace EpicRPGBot.UI
             _lastMessagesPanel = (System.Windows.Controls.Grid)FindName("LastMessagesPanel");
             _huntCountText = (System.Windows.Controls.TextBlock)FindName("HuntCountText");
 
+            // Setup cooldown label mapping + ticking
+            InitCooldownTracking();
+            
             await InitializeWebViewAsync();
             await NavigateToChannelAsync(GetChannelUrl());
             StartPollingLastMessage();
@@ -156,6 +168,8 @@ namespace EpicRPGBot.UI
                     {
                         _prevPolled = msg;
                         UiDispatcher.OnUI(_last.Add, msg);
+                        // Parse and apply cooldowns when the 'cooldowns' message appears
+                        UiDispatcher.OnUI(() => TryParseCooldowns(msg));
                     }
                 }
                 catch { }
@@ -286,6 +300,179 @@ namespace EpicRPGBot.UI
         private int SafeInt(string s, int def)
         {
             return int.TryParse(s, out var v) ? v : def;
+        }
+
+        // ------------------------- Cooldowns (visual -> functional) -------------------------
+
+        private class CooldownEntry
+        {
+            public TextBlock Label { get; }
+            public TimeSpan? Remaining { get; set; }
+
+            public CooldownEntry(TextBlock label)
+            {
+                Label = label;
+                Remaining = null;
+            }
+        }
+
+        private void InitCooldownTracking()
+        {
+            TextBlock T(string name) => (TextBlock)FindName(name);
+
+            // Canonical -> label
+            // Canonical keys
+            _cooldowns["daily"]      = new CooldownEntry(T("DailyCdText"));
+            _cooldowns["weekly"]     = new CooldownEntry(T("WeeklyCdText"));
+            _cooldowns["lootbox"]    = new CooldownEntry(T("LootboxCdText"));
+            _cooldowns["card_hand"]  = new CooldownEntry(T("CardHandCdText"));
+            _cooldowns["vote"]       = new CooldownEntry(T("VoteCdText"));
+
+            _cooldowns["hunt"]       = new CooldownEntry(T("HuntCdText"));
+            _cooldowns["adventure"]  = new CooldownEntry(T("AdventureCdText"));
+            _cooldowns["training"]   = new CooldownEntry(T("TrainingCdText"));
+            _cooldowns["duel"]       = new CooldownEntry(T("DuelCdText"));
+            _cooldowns["quest"]      = new CooldownEntry(T("QuestCdText"));
+
+            _cooldowns["work"]       = new CooldownEntry(T("WorkCdText"));
+            _cooldowns["farm"]       = new CooldownEntry(T("FarmCdText"));
+            _cooldowns["horse"]      = new CooldownEntry(T("HorseCdText"));
+            _cooldowns["arena"]      = new CooldownEntry(T("ArenaCdText"));
+            _cooldowns["dungeon"]    = new CooldownEntry(T("DungeonCdText"));
+
+            // Aliases from message -> canonical keys
+            void Map(string alias, string canonical) => _aliasToCanonical[alias] = canonical;
+
+            Map("daily", "daily");
+            Map("weekly", "weekly");
+            Map("lootbox", "lootbox");
+            Map("card hand", "card_hand");
+            Map("vote", "vote");
+
+            Map("hunt", "hunt");
+            Map("adventure", "adventure");
+            Map("training", "training");
+            Map("duel", "duel");
+            Map("quest", "quest");
+            Map("epic quest", "quest");
+
+            Map("chop", "work");
+            Map("fish", "work");
+            Map("pickup", "work");
+            Map("mine", "work");
+
+            Map("farm", "farm");
+
+            Map("horse breeding", "horse");
+            Map("horse race", "horse");
+
+            Map("arena", "arena");
+
+            Map("dungeon", "dungeon");
+            Map("miniboss", "dungeon");
+
+            // 1-second ticking to decrement visible timers
+            _cooldownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _cooldownTimer.Tick += (s, e) =>
+            {
+                foreach (var entry in _cooldowns.Values.Distinct())
+                {
+                    if (entry.Label == null) continue;
+
+                    if (entry.Remaining.HasValue)
+                    {
+                        var left = entry.Remaining.Value - TimeSpan.FromSeconds(1);
+                        if (left <= TimeSpan.Zero)
+                        {
+                            entry.Remaining = null; // ready
+                            UpdateCooldownLabel(entry.Label, null);
+                        }
+                        else
+                        {
+                            entry.Remaining = left;
+                            UpdateCooldownLabel(entry.Label, left);
+                        }
+                    }
+                }
+            };
+            _cooldownTimer.Start();
+        }
+
+        private void TryParseCooldowns(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message)) return;
+            if (message.IndexOf("cooldowns", StringComparison.OrdinalIgnoreCase) < 0) return;
+
+            var lines = message.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var raw in lines)
+            {
+                var line = raw.Trim();
+                if (string.IsNullOrEmpty(line)) continue;
+
+                // Skip headings
+                var header = line.ToLowerInvariant();
+                if (header.Contains("cooldowns") || header == "rewards" || header == "experience" || header == "progress")
+                    continue;
+
+                // Extract "names (time)" where names can be "a | b | c"
+                var match = Regex.Match(line, @"^\s*[~`\-\*]*\s*(.+?)\s*(?:\(([^)]+)\))?\s*$");
+                if (!match.Success) continue;
+
+                var namesPart = match.Groups[1].Value.Trim();
+                var timePart = match.Groups[2].Success ? match.Groups[2].Value.Trim() : null;
+
+                // For each alias in the names, update its canonical cooldown
+                TimeSpan? dur = ParseDuration(timePart); // null => Ready
+                foreach (var alias in namesPart.Split('|'))
+                {
+                    var a = alias.Trim().ToLowerInvariant();
+                    if (_aliasToCanonical.TryGetValue(a, out var canonical) && _cooldowns.TryGetValue(canonical, out var entry))
+                    {
+                        entry.Remaining = dur.HasValue && dur.Value > TimeSpan.Zero ? dur : null;
+                        UpdateCooldownLabel(entry.Label, entry.Remaining);
+                    }
+                }
+            }
+        }
+
+        private static TimeSpan? ParseDuration(string time)
+        {
+            if (string.IsNullOrWhiteSpace(time)) return null; // Ready
+            var matches = Regex.Matches(time, @"(\d+)\s*([dhms])", RegexOptions.IgnoreCase);
+            if (matches.Count == 0) return null;
+
+            int d = 0, h = 0, m = 0, s = 0;
+            foreach (Match mt in matches)
+            {
+                var val = int.Parse(mt.Groups[1].Value);
+                switch (mt.Groups[2].Value.ToLowerInvariant())
+                {
+                    case "d": d = val; break;
+                    case "h": h = val; break;
+                    case "m": m = val; break;
+                    case "s": s = val; break;
+                }
+            }
+
+            try { return new TimeSpan(d, h, m, s); }
+            catch { return null; }
+        }
+
+        private static string FormatDuration(TimeSpan ts)
+        {
+            var parts = new List<string>();
+            if (ts.Days > 0) parts.Add($"{ts.Days}d");
+            if (ts.Days > 0 || ts.Hours > 0) parts.Add($"{ts.Hours}h");
+            if (ts.Days > 0 || ts.Hours > 0 || ts.Minutes > 0) parts.Add($"{ts.Minutes}m");
+            parts.Add($"{ts.Seconds}s");
+            return string.Join(" ", parts);
+        }
+
+        private void UpdateCooldownLabel(TextBlock tb, TimeSpan? remaining)
+        {
+            if (tb == null) return;
+            tb.Text = remaining.HasValue ? FormatDuration(remaining.Value) : "Ready";
         }
 
         // Left header buttons

--- a/EpicRPGBot.UI/docs/MainWindow.xaml.md
+++ b/EpicRPGBot.UI/docs/MainWindow.xaml.md
@@ -11,7 +11,7 @@ Layout
       - StatsPanel: simple counters (e.g., “Hunt sent: N”).
       - ConsolePanel: ListBox (ConsoleList) bound to log entries.
   - Center: WebView2 host (Discord) with a small header row containing navigation buttons.
-  - Right: 300px settings panel including channel URL, bot parameters and Start/Stop buttons.
+  - Right: 300px settings panel including channel URL, bot parameters, Start/Stop buttons, and a “Cooldowns (visual)” list rendered under the Start/Stop buttons.
 
 Key named elements
 - LastMessagesTabBtn / StatsTabBtn / ConsoleTabBtn: toggle which panel is visible in the left column.
@@ -28,3 +28,7 @@ Notes
 - Uses a dark theme palette aligned loosely with Discord.
 - Top row in the center provides Reload and “Go To Channel” actions.
 - XAML names are referenced in code-behind for logic and bindings.
+- Better Settings: The right panel shows a read-only “Cooldowns (visual)” section that lists common Epic RPG commands with placeholder timers:
+  - Rewards: daily, weekly, lootbox, card hand, vote
+  - Experience: hunt, adventure, training, duel, quest | epic quest
+  - Progress: chop | fish | pickup | mine, farm, horse breeding | horse race, arena, dungeon | miniboss

--- a/EpicRPGBot.UI/docs/MainWindow.xaml.md
+++ b/EpicRPGBot.UI/docs/MainWindow.xaml.md
@@ -32,3 +32,62 @@ Notes
   - Rewards: daily, weekly, lootbox, card hand, vote
   - Experience: hunt, adventure, training, duel, quest | epic quest
   - Progress: chop | fish | pickup | mine, farm, horse breeding | horse race, arena, dungeon | miniboss
+## Inicialize button (concept for Hunt)
+
+- Added an "Inicialize" button next to Start/Stop in the right panel in [MainWindow.xaml](EpicRPGBot.UI/MainWindow.xaml:1) with name InitBtn.
+- Behavior implemented in [InitBtn_Click()](EpicRPGBot.UI/MainWindow.xaml.cs:1):
+  - Sends "rpg hunt h".
+  - Waits 2 seconds.
+  - Sends "rpg cd".
+  - Parses the resulting cooldowns message and reads the hunt remaining time.
+  - Adds a 3-second safety margin to the parsed hunt time.
+  - Persists this as milliseconds to a local settings file:
+    - Path: %LocalAppData%/EpicRPGBot.UI/settings/cooldowns.ini
+    - Format: hunt_ms=&lt;milliseconds&gt;
+  - Updates the Hunt cooldown textbox (HuntCdBox) to this persisted value.
+
+- On application load, if this file exists, the stored hunt_ms is used; otherwise a default of 61,000ms (1m 1s) is assumed and written into the UI textbox.
+
+Notes
+- This is currently implemented only for the "hunt" command as a concept for the full initialization flow to be extended to other cooldowns.
+- Visual cooldown labels on the right are still driven by parsing of the "rpg cooldowns" message and a 1s ticking timer; initialization just establishes a persisted baseline for internal scheduling and UI.
+## Inicialize button (multi-command setup)
+
+- An "Inicialize" button sits next to Start/Stop in [MainWindow.xaml](EpicRPGBot.UI/MainWindow.xaml:1) (Name: InitBtn).
+- Entry point: [InitBtn_Click()](EpicRPGBot.UI/MainWindow.xaml.cs:325)
+- Helper used per command: InitializeOneAsync(...) in [MainWindow.xaml.cs](EpicRPGBot.UI/MainWindow.xaml.cs:551)
+
+Purpose
+- Establish persisted baseline cooldowns by issuing commands and reading the resulting "rpg cd" output, adding a safety overhead for lag, then saving per-command milliseconds and updating UI inputs.
+
+Sequence (applied per command)
+1) Send the action command.
+2) Wait 2 seconds.
+3) Send "rpg cd".
+4) Wait 1 second + extra 1 second (render/lag buffer).
+5) Parse the cooldowns message and read the remaining time for that command.
+6) Add an overhead of 2 + 1 + 1 = 4 seconds to the remaining time and persist (milliseconds).
+7) Update UI textbox for commands that have one (Hunt, Work, Farm).
+8) Wait 3 seconds before moving to the next command.
+
+Commands initialized
+- Hunt: action "rpg hunt h" → persists hunt_ms, updates HuntCdBox
+- Adventure: action "rpg adventure" → persists adventure_ms (no textbox)
+- Farm: action "rpg farm" → persists farm_ms, updates FarmCdBox
+- Work: action "rpg chainsaw" → persists work_ms, updates WorkCdBox
+
+Persistence
+- File: %LocalAppData%/EpicRPGBot.UI/settings/cooldowns.ini
+- Keys (milliseconds): 
+  - hunt_ms=
+  - adventure_ms=
+  - work_ms=
+  - farm_ms=
+- On app load (UI), if present:
+  - HuntCdBox uses hunt_ms (default: 61,000 ms)
+  - WorkCdBox uses work_ms (default: current UI value if not found)
+  - FarmCdBox uses farm_ms (default: current UI value if not found)
+
+Notes
+- Visual cooldown labels remain driven by parsing the "rpg cooldowns" message and a 1s ticking timer; Inicialize establishes persisted baselines used by inputs and engine scheduling.
+- Sending uses WebView2 DevTools (Input.insertText + Enter keyDown/keyUp) with a fallback to execCommand to guarantee actual message submission.


### PR DESCRIPTION
Implements an Inicialize sequence that: sends each action (hunt/adventure/farm/chainsaw), waits 2s, sends rpg cd, waits 1s + extra 1s, parses cooldowns, adds 4s overhead, persists ms (hunt_ms/adventure_ms/work_ms/farm_ms) to C:\Users\thesa\AppData\Local/EpicRPGBot.UI/settings/cooldowns.ini, updates UI (Hunt/Work/Farm), and waits 3s between commands. Also upgrades message sending to DevTools Enter dispatch, and updates docs.